### PR TITLE
fixing the source link+ a typo

### DIFF
--- a/current-info/index.html
+++ b/current-info/index.html
@@ -45,12 +45,9 @@
       </header>
        
         <h1>What We Know</h1>
-        <p> Place holder for text and images here </p>
-        <img src="iowa_shooting.jpg" alt="Perry High School after January 4th mass shooting" width="1700" height="1600">
+        <img src="Perry_image.jpg" alt="Police officers walking next to Perry high school" width="1500" height="900">
         <p> Taken from
-        <a href="https://www.cnn.com/2024/01/05/us/perry-iowa-school-shooting-friday/index.html">CNN</a>
-
-        <img src="Perry_image.jpg" alt="Cups walking next to Perry high school" width="1500" height="900">
+        <a href="https://www.lemonde.fr/en/international/article/2024/01/04/multiple-gunshot-victims-in-iowa-school-shooting-says-sheriff_6401953_4.html">Le Momd</a></p>
 
         <h1>January 5th Update from the Iowa Department of Public Safety</h1>
 


### PR DESCRIPTION
Hey, 
just fixed the Perry High School image:
1) I added the correct link (to Le Mond https://www.lemonde.fr/en/international/article/2024/01/04/multiple-gunshot-victims-in-iowa-school-shooting-says-sheriff_6401953_4.html)
2) I fixed the image's description typo 
3) I deleted the connection to the old image 

Thanks, 
Gal 